### PR TITLE
Add onboarding flow with animations

### DIFF
--- a/app-frontend/app/index.js
+++ b/app-frontend/app/index.js
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { useRouter } from 'expo-router';
 
 export default function Index() {
-  const { user, loading } = useAuth();
+  const { user, loading, onboardingDone } = useAuth();
   const router = useRouter();
   const [hasMounted, setHasMounted] = useState(false);
 
@@ -16,13 +16,15 @@ export default function Index() {
   // 2. Une fois monté et loading terminé, on redirige
   useEffect(() => {
     if (hasMounted && !loading) {
-      if (user) {
+      if (!onboardingDone) {
+        router.replace('/onboarding');
+      } else if (user) {
         router.replace('/dashboard');
       } else {
         router.replace('/login');
       }
     }
-  }, [hasMounted, loading, user]);
+  }, [hasMounted, loading, user, onboardingDone]);
 
   return null;
 }

--- a/app-frontend/context/AuthContext.js
+++ b/app-frontend/context/AuthContext.js
@@ -8,6 +8,7 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [authToken, setAuthToken] = useState(null);
+  const [onboardingDone, setOnboardingDone] = useState(false);
 
   const loadUserFromToken = useCallback(async (token) => {
     if (!token) {
@@ -37,6 +38,8 @@ export const AuthProvider = ({ children }) => {
       try {
         const token = await SecureStore.getItemAsync('authToken');
         setAuthToken(token || null);
+        const done = await SecureStore.getItemAsync('onboardingDone');
+        setOnboardingDone(done === 'true');
         if (token) {
           await loadUserFromToken(token);
         } else {
@@ -75,6 +78,11 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
   };
 
+  const completeOnboarding = async () => {
+    await SecureStore.setItemAsync('onboardingDone', 'true');
+    setOnboardingDone(true);
+  };
+
   // FONCTION **reloadUser** à utiliser après achat
   const reloadUser = useCallback(async () => {
     setLoading(true);
@@ -101,8 +109,10 @@ export const AuthProvider = ({ children }) => {
         loading,
         login,
         logout,
+        completeOnboarding,
         reloadUser,
         authToken,
+        onboardingDone,
       }}
     >
       {children}

--- a/app-frontend/screens/DashboardScreen.js
+++ b/app-frontend/screens/DashboardScreen.js
@@ -37,7 +37,8 @@ import { useStripe } from '@stripe/stripe-react-native'; // ← Stripe
 const SCREEN_WIDTH = Dimensions.get('window').width;
 let confettiAnim;
 try {
-  confettiAnim = require('../../assets/animations/confetti.json');
+  // Correct relative path to animation asset
+  confettiAnim = require('../assets/animations/confetti.json');
 } catch {
   confettiAnim = null;
 }

--- a/app-frontend/screens/OnboardingScreen.js
+++ b/app-frontend/screens/OnboardingScreen.js
@@ -1,42 +1,64 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, Dimensions } from 'react-native';
+import LottieView from 'lottie-react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
 import { useAuth } from '../context/AuthContext';
 
 const { width } = Dimensions.get('window');
 
 const slides = [
   {
-    title: 'Bienvenue sur ConsentApp',
-    description: 'Gérez vos consentements en toute simplicité et sécurité.',
-    image: 'https://img.icons8.com/color/96/consent.png',
+    title: 'Créez votre demande',
+    description: 'Sélectionnez votre partenaire et définissez les conditions.',
+    lottie: require('../assets/animations/hero.json'),
   },
   {
-    title: 'Créez et suivez vos demandes',
-    description: 'Envoyez, recevez et archivez vos consentements avec vos contacts.',
-    image: 'https://img.icons8.com/color/96/contract-job.png',
+    title: 'Validez avec la biométrie',
+    description: 'Confirmez votre identité grâce à votre empreinte digitale.',
+    icon: 'finger-print',
   },
   {
-    title: 'Sécurité et confidentialité',
-    description: 'Toutes vos données sont protégées et chiffrées.',
-    image: 'https://img.icons8.com/color/96/lock--v1.png',
+    title: 'Consentement confirmé',
+    description: 'Recevez une preuve sécurisée et notifiez votre partenaire.',
+    lottie: require('../assets/animations/confetti.json'),
   },
 ];
 
-export default function OnboardingScreen({ navigation }) {
+export default function OnboardingScreen() {
   const [current, setCurrent] = useState(0);
+  const router = useRouter();
   const { completeOnboarding } = useAuth();
+
+  const renderIllustration = () => {
+    const slide = slides[current];
+    if (slide.lottie) {
+      return (
+        <LottieView
+          source={slide.lottie}
+          autoPlay
+          loop
+          style={styles.lottie}
+        />
+      );
+    }
+    if (slide.icon) {
+      return <Ionicons name={slide.icon} size={width * 0.5} color="#3B82F6" style={styles.icon} />;
+    }
+    return <Image source={{ uri: slide.image }} style={styles.image} />;
+  };
 
   const nextSlide = async () => {
     if (current < slides.length - 1) setCurrent(current + 1);
     else {
       await completeOnboarding();
-      navigation.replace('Login');
+      router.replace('/login');
     }
   };
 
   return (
     <View style={styles.container}>
-      <Image source={{ uri: slides[current].image }} style={styles.image} />
+      {renderIllustration()}
       <Text style={styles.title}>{slides[current].title}</Text>
       <Text style={styles.description}>{slides[current].description}</Text>
       <TouchableOpacity style={styles.button} onPress={nextSlide}>
@@ -64,6 +86,14 @@ const styles = StyleSheet.create({
     height: width * 0.5,
     marginBottom: 32,
     resizeMode: 'contain',
+  },
+  lottie: {
+    width: width * 0.6,
+    height: width * 0.6,
+    marginBottom: 32,
+  },
+  icon: {
+    marginBottom: 32,
   },
   title: {
     fontSize: 26,


### PR DESCRIPTION
## Summary
- implement onboarding slides using Lottie and vector icons
- track onboarding completion in `AuthContext`
- redirect to onboarding screen on first launch

## Testing
- `npm test` *(fails: missing `package.json`)*
- `npm test` in `app-backend` *(fails: no `test` script)*
- `npm test` in `app-frontend` *(fails: no `test` script)*
- `npm run lint` in `app-frontend` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684becbbcf308327b0d92c5a9dcda12e