### PR TITLE
Fix consent card logic for initiator

### DIFF
--- a/app-frontend/components/ConsentCard.js
+++ b/app-frontend/components/ConsentCard.js
@@ -16,6 +16,9 @@ function getSummary(consent, userId) {
     }
   }
   if (consent.status === 'ACCEPTED') {
+    if (userId === consent.partnerId) {
+      return `Bravo ! Toi et ${initiateur} avez validé le consentement par biométrie 🎉`;
+    }
     return `Bravo ! Toi et ${partenaire} avez validé le consentement par biométrie 🎉`;
   }
   if (consent.status === 'REFUSED') {
@@ -188,7 +191,7 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
       </View>
 
       {/* Boutons d'action selon statut */}
-      {consent.status === 'PENDING' && (
+      {consent.status === 'PENDING' && isPartner && (
         <View style={styles.actionsRow}>
           <TouchableOpacity style={[styles.actionButton, styles.actionButtonAccept]} onPress={() => handleAccept(consent, onAccept)}>
             <Ionicons name="checkmark" size={20} color="#fff" />


### PR DESCRIPTION
## Summary
- show partner actions only for the partner user
- display initiator name when the partner views the acceptance message

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c80d535cc8327b34759aaaa0c7b84