### PR TITLE
Update consent preview logic

### DIFF
--- a/app-frontend/components/ConsentCard.js
+++ b/app-frontend/components/ConsentCard.js
@@ -8,21 +8,30 @@ import { acceptConsent, refuseConsent } from '../utils/api';
 function getSummary(consent, userId) {
   const initiateur = consent.user?.firstName || 'Quelqu’un';
   const partenaire = consent.partner?.firstName || consent.partner?.email?.split('@')[0] || 'un contact';
+  if (consent.status === 'DRAFT') {
+    // Prévisualisation avant validation biométrique : on affiche uniquement la citation de consentement
+    return `🗨️ "Je consens à avoir une relation sexuelle avec ${partenaire}."`;
+  }
   if (consent.status === 'PENDING') {
     if (userId === consent.userId) {
-      return `En attente de la validation biométrique de ${partenaire}`;
-    } else {
-      return `${initiateur} attend ta validation biométrique !`;
+      return `En route ! Il ne manque plus que la validation de ${partenaire} pour confirmer ce consentement.`;
     }
+    if (userId === consent.partnerId) {
+      return `${initiateur} souhaite officialiser un moment avec toi. À toi de confirmer ou de refuser ce consentement.`;
+    }
+    return `Consentement en attente de la validation de ${partenaire}.`;
   }
   if (consent.status === 'ACCEPTED') {
-    if (userId === consent.partnerId) {
-      return `Bravo ! Toi et ${initiateur} avez validé le consentement par biométrie 🎉`;
-    }
-    return `Bravo ! Toi et ${partenaire} avez validé le consentement par biométrie 🎉`;
+    return `🎉 C’est officiel ! Vous avez tous les deux validé ce consentement par empreinte biométrique.`;
   }
   if (consent.status === 'REFUSED') {
-    return `Consentement refusé par ${userId === consent.partnerId ? 'toi' : partenaire}`;
+    if (userId === consent.userId) {
+      return `❌ ${partenaire} a choisi de ne pas confirmer ce consentement. 💡 Tu peux en discuter ensemble si besoin, ou créer une nouvelle demande plus tard.`;
+    }
+    if (userId === consent.partnerId) {
+      return '❌ Tu as refusé cette demande.';
+    }
+    return 'Consentement refusé.';
   }
   return 'Statut inconnu';
 }

--- a/app-frontend/screens/ConsentWizard.js
+++ b/app-frontend/screens/ConsentWizard.js
@@ -6,6 +6,7 @@ import { COLORS, SIZES } from '../constants';
 import { api } from '../utils/api';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { useRouter } from 'expo-router';
+import { useAuth } from '../context/AuthContext';
 
 const steps = [
   'PARTNER',
@@ -20,6 +21,7 @@ export default function ConsentWizard() {
   const [biometryValidated, setBiometryValidated] = useState(false);
   const [error, setError] = useState(null);
   const router = useRouter();
+  const { user } = useAuth();
 
   const handleNext = () => setStep((s) => Math.min(s + 1, steps.length - 1));
   const handleBack = () => setStep((s) => Math.max(s - 1, 0));
@@ -91,23 +93,29 @@ export default function ConsentWizard() {
             consent={{
               user: { firstName: 'Moi', avatarUrl: '' },
               partner: partner && typeof partner === 'object' ? partner : { firstName: '', avatarUrl: '' },
-              message: partner && partner.firstName ? `Je consens à avoir une relation sexuelle avec ${partner.firstName}.` : '',
+              // Pour l'aperçu avant signature, on souhaite uniquement afficher la citation
+              message: '',
               createdAt: new Date().toISOString(),
-              status: 'PENDING',
+              status: 'DRAFT',
             }}
-            userId={-1}
+            userId={user?.id ?? -1}
           />
 
           {/* -------- PATCH BIOMÉTRIQUE -------- */}
           {!biometryValidated ? (
             <TouchableOpacity style={styles.button} onPress={handleBiometricAuth} disabled={loading}>
-              <Text style={styles.buttonText}>{loading ? 'Vérification...' : 'Signer avec empreinte digitale'}</Text>
+              <Text style={styles.buttonText}>{loading ? 'Vérification...' : 'Signer avec mon empreinte digitale'}</Text>
             </TouchableOpacity>
           ) : (
             <>
-              <Text style={{ color: 'green', marginVertical: 10, fontFamily: 'Poppins-Bold' }}>Validation biométrique OK ✅</Text>
+              <Text style={{ color: 'green', marginVertical: 10, fontFamily: 'Poppins-Bold', textAlign: 'center' }}>
+                {`✅ C’est fait ! Ta signature biométrique est enregistrée.`}
+              </Text>
+              <Text style={{ marginBottom: 10, fontFamily: 'Poppins-Regular', textAlign: 'center' }}>
+                {`🚀 Envoie maintenant ta demande à ${partner?.firstName || partner?.email || 'ton partenaire'} pour finaliser ensemble ce moment d’engagement mutuel.`}
+              </Text>
               <TouchableOpacity style={styles.button} onPress={handleSubmit} disabled={loading}>
-                <Text style={styles.buttonText}>{loading ? 'Envoi...' : 'Envoyer le consentement'}</Text>
+                <Text style={styles.buttonText}>{loading ? 'Envoi...' : `Envoyer la demande à ${partner?.firstName || partner?.email || 'ton partenaire'}`}</Text>
               </TouchableOpacity>
             </>
           )}


### PR DESCRIPTION
## Summary
- show consent quote in preview before signature
- ensure partner name is displayed consistently

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0db0b5b483279b15e1b416d86029