### PR TITLE
Add consent notification system

### DIFF
--- a/app-frontend/app/_layout.tsx
+++ b/app-frontend/app/_layout.tsx
@@ -2,11 +2,13 @@
 // @ts-ignore
 import { AuthProvider } from '../context/AuthContext';
 import { Slot } from 'expo-router';
+import ConsentToast from '../components/notifications/ConsentToast';
 
 export default function RootLayout() {
   return (
     <AuthProvider>
       <Slot />
+      <ConsentToast />
     </AuthProvider>
   );
 }

--- a/app-frontend/components/ConsentCard.js
+++ b/app-frontend/components/ConsentCard.js
@@ -3,6 +3,9 @@ import { View, Text, Image, StyleSheet, TouchableOpacity, Animated } from 'react
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { acceptConsent, refuseConsent } from '../utils/api';
+import useConsentNotifications from '../hooks/useConsentNotifications';
+import ConsentModal from './notifications/ConsentModal';
+import { consentMessages } from '../lib/notifications/messages';
 
 function getSummary(consent, userId) {
   const initiateur = consent.user?.firstName || 'Quelqu’un';
@@ -69,7 +72,10 @@ function isConsentValid(consent) {
 }
 
 export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
-  if (!isConsentValid(consent)) {
+  const valid = isConsentValid(consent);
+  const isInitiator = valid && consent.userId === userId;
+  const { modalVisible, setModalVisible } = useConsentNotifications(valid ? consent : null, isInitiator);
+  if (!valid) {
     return (
       <View style={{ padding: 16, backgroundColor: '#fee2e2', borderRadius: 10, margin: 8 }}>
         <Text style={{ color: '#b91c1c', fontWeight: 'bold' }}>Erreur : consentement mal formé</Text>
@@ -77,10 +83,7 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
       </View>
     );
   }
-
-  const isInitiator = consent.userId === userId;
   const isPartner = consent.partnerId === userId;
-
   const statusColor =
     consent.status === 'PENDING' ? '#F59E42' :
     consent.status === 'ACCEPTED' ? '#22C55E' :
@@ -135,7 +138,8 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
   }, [fadeAnim]);
 
   return (
-    <Animated.View style={[styles.card, { opacity: fadeAnim }]}>  
+    <>
+    <Animated.View style={[styles.card, { opacity: fadeAnim }]}>
       <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
         {!!consent.emoji && <Text style={styles.emoji}>{safeText(consent.emoji)}</Text>}
         {!!consent.type && <Text style={styles.type}>{safeText(consent.type)}</Text>}
@@ -180,6 +184,13 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
         </View>
       )}
     </Animated.View>
+    <ConsentModal
+      visible={modalVisible}
+      message={consentMessages.PENDING_PARTNER(consent)}
+      onClose={() => setModalVisible(false)}
+      onAction={() => setModalVisible(false)}
+    />
+    </>
   );
 }
 

--- a/app-frontend/components/notifications/ConsentModal.tsx
+++ b/app-frontend/components/notifications/ConsentModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+
+export default function ConsentModal({ visible, message, onClose, onAction }: {
+  visible: boolean;
+  message: string;
+  onClose: () => void;
+  onAction: () => void;
+}) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.message}>{message}</Text>
+          <TouchableOpacity style={styles.action} onPress={onAction}>
+            <Text style={styles.actionText}>Ouvrir</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.close} onPress={onClose}>
+            <Text style={styles.closeText}>Fermer</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.3)', justifyContent: 'center', alignItems: 'center' },
+  container: { backgroundColor: '#fff', padding: 24, borderRadius: 20, width: '80%' },
+  message: { fontSize: 16, marginBottom: 20, textAlign: 'center' },
+  action: { backgroundColor: '#6366f1', borderRadius: 14, padding: 12, marginBottom: 12 },
+  actionText: { color: '#fff', textAlign: 'center', fontWeight: 'bold' },
+  close: { padding: 8 },
+  closeText: { color: '#6366f1', textAlign: 'center' },
+});

--- a/app-frontend/components/notifications/ConsentToast.tsx
+++ b/app-frontend/components/notifications/ConsentToast.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Toast from 'react-native-toast-message';
+
+export function showConsentToast(message: string, type: 'info' | 'success' | 'error' = 'info') {
+  Toast.show({ type, text1: message, position: 'bottom' });
+}
+
+export default function ConsentToast() {
+  return <Toast config={toastConfig} />;
+}
+
+const toastConfig = {
+  info: ({ text1 }: any) => (
+    <View style={[styles.base, styles.info]}>
+      <Text style={styles.text}>{text1}</Text>
+    </View>
+  ),
+  success: ({ text1 }: any) => (
+    <View style={[styles.base, styles.success]}>
+      <Text style={styles.text}>{text1}</Text>
+    </View>
+  ),
+  error: ({ text1 }: any) => (
+    <View style={[styles.base, styles.error]}>
+      <Text style={styles.text}>{text1}</Text>
+    </View>
+  ),
+};
+
+const styles = StyleSheet.create({
+  base: {
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    borderRadius: 20,
+    marginBottom: 40,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  text: { color: '#222', fontSize: 15, fontWeight: '600' },
+  info: { backgroundColor: '#e0e7ff' },
+  success: { backgroundColor: '#d1fae5' },
+  error: { backgroundColor: '#fee2e2' },
+});

--- a/app-frontend/hooks/useConsentNotifications.ts
+++ b/app-frontend/hooks/useConsentNotifications.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import * as Haptics from 'expo-haptics';
+import { Audio } from 'expo-av';
+import { consentMessages } from '../lib/notifications/messages';
+import { showConsentToast } from '../components/notifications/ConsentToast';
+
+export default function useConsentNotifications(consent: any, isInitiator = true) {
+  const [lastStatus, setLastStatus] = useState(consent?.status);
+  const [modalVisible, setModalVisible] = useState(false);
+
+  useEffect(() => {
+    if (!consent || !consent.status) return;
+    if (consent.status === lastStatus) return;
+    setLastStatus(consent.status);
+
+    switch (consent.status) {
+      case 'DRAFT':
+        showConsentToast(consentMessages.DRAFT(consent));
+        break;
+      case 'PENDING':
+        if (isInitiator) {
+          showConsentToast(consentMessages.PENDING_INITIATOR(consent));
+        } else {
+          setModalVisible(true);
+        }
+        break;
+      case 'ACCEPTED':
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        playSound();
+        showConsentToast(consentMessages.ACCEPTED(consent), 'success');
+        break;
+      case 'REFUSED':
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        showConsentToast(consentMessages.REFUSED(consent), 'error');
+        break;
+      default:
+        break;
+    }
+  }, [consent?.status, isInitiator]);
+
+  const playSound = async () => {
+    try {
+      const { sound } = await Audio.Sound.createAsync(
+        require('../assets/sounds/notification.ogg')
+      );
+      await sound.playAsync();
+    } catch {}
+  };
+
+  return { modalVisible, setModalVisible };
+}

--- a/app-frontend/lib/notifications/messages.js
+++ b/app-frontend/lib/notifications/messages.js
@@ -1,0 +1,7 @@
+export const consentMessages = {
+  DRAFT: consent => `✍️ Tu es en train de créer un consentement. Pense à le signer pour continuer.`,
+  PENDING_INITIATOR: (consent) => `🚀 Ta demande a bien été envoyée à ${consent.partner?.firstName || 'ton partenaire'}. En attente de sa validation.`,
+  PENDING_PARTNER: (consent) => `📬 Tu viens de recevoir une demande de consentement de ${consent.user?.firstName || 'un contact'}. Ouvre-la pour agir !`,
+  ACCEPTED: consent => `🎉 Consentement confirmé avec ${consent.partner?.firstName || consent.user?.firstName || 'ton partenaire'} ! Un moment à deux, validé avec respect.`,
+  REFUSED: consent => `❌ ${consent.partner?.firstName || consent.user?.firstName || 'Cette personne'} a refusé la demande. Ce n’est pas un non définitif. Tu peux réessayer plus tard.`,
+};

--- a/app-frontend/package-lock.json
+++ b/app-frontend/package-lock.json
@@ -39,6 +39,7 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "^5.4.0",
         "react-native-screens": "~4.10.0",
+        "react-native-toast-message": "^2.1.6",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5"
       },
@@ -10776,6 +10777,16 @@
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.1.6.tgz",
+      "integrity": "sha512-VctXuq20vmRa9AE13acaNZhrLcS3FaBS2zEevS3+vhBsnVZYG0FIlWIis9tVnpnNxUb3ART+BWtwQjzSttXTng==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -42,6 +42,7 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.10.0",
+    "react-native-toast-message": "^2.1.6",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5"
   },


### PR DESCRIPTION
## Summary
- add toast container in root layout
- create toast and modal components for consent status
- implement `useConsentNotifications` hook
- integrate notifications into `ConsentCard`
- store dynamic messages in `lib/notifications`
- install `react-native-toast-message`

## Testing
- `npm run lint` *(fails: import/no-unresolved and hooks rules issues)*

------
https://chatgpt.com/codex/tasks/task_e_685038eefe088327a8c3ff0e6f4bc756