### PR TITLE
Enhance notification hook and messages

### DIFF
--- a/app-frontend/app/_layout.tsx
+++ b/app-frontend/app/_layout.tsx
@@ -1,12 +1,21 @@
 // app/_layout.tsx
 // @ts-ignore
 import { AuthProvider } from '../context/AuthContext';
+import { NotificationSettingsProvider } from '../context/NotificationSettingsContext';
+import { ConsentNotificationProvider } from '../hooks/useConsentNotifications';
+import ConsentStatusWatcher from '../hooks/useConsentStatusWatcher';
 import { Slot } from 'expo-router';
 
 export default function RootLayout() {
   return (
     <AuthProvider>
-      <Slot />
+      <NotificationSettingsProvider>
+        <ConsentNotificationProvider>
+          <ConsentStatusWatcher>
+            <Slot />
+          </ConsentStatusWatcher>
+        </ConsentNotificationProvider>
+      </NotificationSettingsProvider>
     </AuthProvider>
   );
 }

--- a/app-frontend/components/ConsentCard.js
+++ b/app-frontend/components/ConsentCard.js
@@ -69,8 +69,17 @@ function isConsentValid(consent) {
 }
 
 export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
   const valid = isConsentValid(consent);
   const isInitiator = valid && consent.userId === userId;
+  useEffect(() => {
+    if (!valid) return;
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 400,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim, valid]);
   if (!valid) {
     return (
       <View style={{ padding: 16, backgroundColor: '#fee2e2', borderRadius: 10, margin: 8 }}>
@@ -103,6 +112,7 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
   const userLabel = safeText(getAvatarLabel(isInitiator, consent.user, 'Moi'), 'userLabel');
   const partnerLabel = safeText(getAvatarLabel(isPartner, consent.partner, 'Partenaire'), 'partnerLabel');
 
+
   function handleAccept() {
     LocalAuthentication.authenticateAsync({ promptMessage: 'Validez avec votre empreinte digitale' })
       .then(result => {
@@ -123,15 +133,6 @@ export default function ConsentCard({ consent, userId, onAccept, onRefuse }) {
       .catch(err => alert(err.message || 'Erreur lors du refus du consentement'));
   }
 
-  const fadeAnim = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    Animated.timing(fadeAnim, {
-      toValue: 1,
-      duration: 400,
-      useNativeDriver: true,
-    }).start();
-  }, [fadeAnim]);
 
   return (
     <>

--- a/app-frontend/components/notifications/ConsentModal.js
+++ b/app-frontend/components/notifications/ConsentModal.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { COLORS } from '../../constants';
+
+export default function ConsentModal({ visible, message, onAccept, onRefuse, onClose }) {
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.backdrop}>
+        <View style={styles.modalBox}>
+          <Text style={styles.text}>{message}</Text>
+          <View style={styles.actions}>
+            {onAccept && (
+              <TouchableOpacity style={[styles.btn, styles.accept]} onPress={onAccept}>
+                <Text style={styles.btnText}>Accepter</Text>
+              </TouchableOpacity>
+            )}
+            {onRefuse && (
+              <TouchableOpacity style={[styles.btn, styles.refuse]} onPress={onRefuse}>
+                <Text style={styles.btnText}>Refuser</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+          {onClose && (
+            <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
+              <Text style={styles.closeText}>Fermer</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalBox: {
+    backgroundColor: '#fff',
+    borderRadius: 20,
+    padding: 20,
+    width: '85%',
+  },
+  text: { textAlign: 'center', color: COLORS.text, marginBottom: 20 },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  btn: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 12,
+  },
+  accept: {
+    backgroundColor: COLORS.success,
+  },
+  refuse: {
+    backgroundColor: COLORS.danger,
+  },
+  btnText: { color: '#fff', fontWeight: 'bold' },
+  closeBtn: { marginTop: 10, alignSelf: 'center' },
+  closeText: { color: COLORS.text },
+});

--- a/app-frontend/components/notifications/ConsentToast.js
+++ b/app-frontend/components/notifications/ConsentToast.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { COLORS } from '../../constants';
+
+export default function ConsentToast({ message, onHide }) {
+  const slideAnim = useRef(new Animated.Value(100)).current;
+
+  useEffect(() => {
+    Animated.sequence([
+      Animated.timing(slideAnim, { toValue: 0, duration: 300, useNativeDriver: true }),
+      Animated.delay(3500),
+      Animated.timing(slideAnim, { toValue: 100, duration: 300, useNativeDriver: true }),
+    ]).start(() => onHide && onHide());
+  }, [slideAnim, onHide]);
+
+  return (
+    <Animated.View style={[styles.toast, { transform: [{ translateY: slideAnim }] }] }>
+      <Text style={styles.text}>{message}</Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    bottom: 30,
+    left: 20,
+    right: 20,
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 14,
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 2 },
+  },
+  text: { color: COLORS.text, textAlign: 'center' },
+});

--- a/app-frontend/components/notifications/NotificationBanner.js
+++ b/app-frontend/components/notifications/NotificationBanner.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { COLORS } from '../../constants';
+
+export default function NotificationBanner({ message, onHide }) {
+  const slideAnim = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    Animated.sequence([
+      Animated.timing(slideAnim, { toValue: 0, duration: 300, useNativeDriver: true }),
+      Animated.delay(3500),
+      Animated.timing(slideAnim, { toValue: -100, duration: 300, useNativeDriver: true }),
+    ]).start(() => onHide && onHide());
+  }, [slideAnim, onHide]);
+
+  return (
+    <Animated.View style={[styles.banner, { transform: [{ translateY: slideAnim }] }] }>
+      <Text style={styles.text}>{message}</Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    position: 'absolute',
+    top: 50,
+    left: 20,
+    right: 20,
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 14,
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 2 },
+  },
+  text: { color: COLORS.text, textAlign: 'center' },
+});

--- a/app-frontend/context/NotificationSettingsContext.js
+++ b/app-frontend/context/NotificationSettingsContext.js
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as SecureStore from 'expo-secure-store';
+
+const NotificationSettingsContext = createContext();
+
+export const NotificationSettingsProvider = ({ children }) => {
+  const [silent, setSilent] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const val = await SecureStore.getItemAsync('silentMode');
+      setSilent(val === 'true');
+    })();
+  }, []);
+
+  const toggleSilent = async () => {
+    const newVal = !silent;
+    setSilent(newVal);
+    await SecureStore.setItemAsync('silentMode', newVal ? 'true' : 'false');
+  };
+
+  return (
+    <NotificationSettingsContext.Provider value={{ silent, toggleSilent }}>
+      {children}
+    </NotificationSettingsContext.Provider>
+  );
+};
+
+export const useNotificationSettings = () => useContext(NotificationSettingsContext);

--- a/app-frontend/hooks/useConsentNotifications.js
+++ b/app-frontend/hooks/useConsentNotifications.js
@@ -1,0 +1,129 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import * as Haptics from 'expo-haptics';
+import { Audio } from 'expo-av';
+import ConsentToast from '../components/notifications/ConsentToast';
+import ConsentModal from '../components/notifications/ConsentModal';
+import NotificationBanner from '../components/notifications/NotificationBanner';
+import SafeLottieView from '../components/SafeLottieView';
+import { useNotificationSettings } from '../context/NotificationSettingsContext';
+import { ConsentMessages } from '../lib/notifications/messages';
+
+const SUCCESS_SOUND_URL =
+  'https://raw.githubusercontent.com/anars/blank-audio/master/1-second-of-silence.mp3';
+const ERROR_SOUND_URL =
+  'https://raw.githubusercontent.com/anars/blank-audio/master/1-second-of-silence.mp3';
+
+const ConsentNotificationContext = createContext();
+
+export const ConsentNotificationProvider = ({ children }) => {
+  const [toast, setToast] = useState(null);
+  const [modal, setModal] = useState(null);
+  const [banner, setBanner] = useState(null);
+  const [celebrate, setCelebrate] = useState(false);
+
+  const hideToast = () => setToast(null);
+  const hideModal = () => setModal(null);
+
+  return (
+    <ConsentNotificationContext.Provider value={{ setToast, setModal, setBanner, setCelebrate }}>
+      {children}
+      {toast && <ConsentToast message={toast} onHide={hideToast} />}
+      {banner && <NotificationBanner message={banner} onHide={() => setBanner(null)} />}
+      {modal && (
+        <ConsentModal
+          visible={!!modal}
+          message={modal.message}
+          onAccept={modal.onAccept}
+          onRefuse={modal.onRefuse}
+          onClose={hideModal}
+        />
+      )}
+      {celebrate && (
+        <SafeLottieView
+          source={require('../assets/animations/confetti.json')}
+          autoPlay
+          loop={false}
+          onAnimationFinish={() => setCelebrate(false)}
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+        />
+      )}
+    </ConsentNotificationContext.Provider>
+  );
+};
+
+export const useConsentNotifications = (consent, currentUserId, actions = {}) => {
+  const { silent } = useNotificationSettings();
+  const { setToast, setModal, setBanner, setCelebrate } = useContext(ConsentNotificationContext);
+  const prevStatus = useRef(consent?.status);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (!consent || !consent.status) return;
+    if (prevStatus.current === consent.status) return;
+    const partnerName =
+      currentUserId === consent.userId
+        ? consent.partner?.firstName || 'ton partenaire'
+        : consent.user?.firstName || 'ce contact';
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      switch (consent.status) {
+        case 'DRAFT':
+          triggerToast(ConsentMessages.draft());
+          break;
+        case 'PENDING':
+          if (currentUserId === consent.userId) {
+            triggerBanner(ConsentMessages.pendingSent(partnerName));
+          } else if (currentUserId === consent.partnerId) {
+            setModal({
+              message: ConsentMessages.pendingReceived(partnerName),
+              onAccept: actions.onAccept,
+              onRefuse: actions.onRefuse,
+            });
+          }
+          break;
+        case 'ACCEPTED':
+          triggerToast(ConsentMessages.accepted(partnerName));
+          if (!silent) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+          playSound({ uri: SUCCESS_SOUND_URL });
+          setCelebrate(true);
+          break;
+        case 'REFUSED':
+          triggerToast(ConsentMessages.refused(partnerName));
+          if (!silent) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+          playSound({ uri: ERROR_SOUND_URL });
+          break;
+        case 'REVOKED':
+          triggerToast(ConsentMessages.revoked(partnerName));
+          if (!silent) Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+          break;
+        case 'EXPIRED':
+          triggerBanner(ConsentMessages.expired(partnerName));
+          break;
+      }
+      prevStatus.current = consent.status;
+    }, 300);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [consent?.status]);
+
+  const triggerToast = (msg) => {
+    setToast(null);
+    setTimeout(() => setToast(msg), 10);
+  };
+  const triggerBanner = (msg) => {
+    setBanner(null);
+    setTimeout(() => setBanner(msg), 10);
+  };
+
+  const playSound = async (module) => {
+    if (silent) return;
+    try {
+      const { sound } = await Audio.Sound.createAsync(module);
+      await sound.playAsync();
+      setTimeout(() => sound.unloadAsync(), 2000);
+    } catch {}
+  };
+};

--- a/app-frontend/hooks/useConsentStatusWatcher.js
+++ b/app-frontend/hooks/useConsentStatusWatcher.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { getConsentHistory } from '../utils/api';
+import { useAuth } from '../context/AuthContext';
+import { useConsentNotifications } from './useConsentNotifications';
+
+function ConsentStatusHandler({ consent, userId }) {
+  useConsentNotifications(consent, userId);
+  return null;
+}
+
+export default function ConsentStatusWatcher({ children }) {
+  const { user } = useAuth();
+  const [consents, setConsents] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    let mounted = true;
+    const fetchConsents = async () => {
+      try {
+        const data = await getConsentHistory();
+        const list = Array.isArray(data) ? data : data.consents || [];
+        if (mounted) setConsents(list);
+      } catch (e) {
+        console.error('fetch consents', e);
+      }
+    };
+    fetchConsents();
+    const interval = setInterval(fetchConsents, 30000);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [user]);
+
+  return (
+    <>
+      {children}
+      {consents.map((c) => (
+        <ConsentStatusHandler key={c.id} consent={c} userId={user?.id} />
+      ))}
+    </>
+  );
+}

--- a/app-frontend/lib/notifications/messages.js
+++ b/app-frontend/lib/notifications/messages.js
@@ -1,0 +1,9 @@
+export const ConsentMessages = {
+  draft: () => '✍️ Tu es en train de créer un consentement. Pense à le signer pour continuer.',
+  pendingSent: (name) => `🚀 Ta demande a bien été envoyée à ${name}. En attente de sa validation.`,
+  pendingReceived: (name) => `📬 Tu viens de recevoir une demande de consentement de ${name}. Ouvre-la pour agir !`,
+  accepted: (name) => `🎉 Consentement confirmé avec ${name} ! Un moment à deux, validé avec respect.`,
+  refused: (name) => `❌ ${name} a refusé la demande. Ce n’est pas un non définitif. Tu peux réessayer plus tard.`,
+  revoked: (name) => `⚠️ ${name} a révoqué son consentement. Toute nouvelle interaction nécessite une nouvelle validation.`,
+  expired: (name) => `⌛ Le consentement avec ${name} est expiré. Relance une nouvelle demande si besoin.`,
+};

--- a/app-frontend/package-lock.json
+++ b/app-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@stripe/stripe-react-native": "^0.45.0",
         "axios": "^1.9.0",
         "expo": "~53.0.8",
+        "expo-av": "^15.1.6",
         "expo-blur": "~14.1.4",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.1",
@@ -6323,6 +6324,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.6.tgz",
+      "integrity": "sha512-5ZbeXdCmdckZHwtEV+8tRZqLlUWR96gkkUIxpyZAEvK0L+aI/BnyhDCpjnSKWwZo4ZA6lx8/su9kyFNV/mQ/sQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-blur": {

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -19,6 +19,7 @@
     "@stripe/stripe-react-native": "^0.45.0",
     "axios": "^1.9.0",
     "expo": "~53.0.8",
+    "expo-av": "^15.1.6",
     "expo-blur": "~14.1.4",
     "expo-constants": "~17.1.6",
     "expo-font": "~13.3.1",


### PR DESCRIPTION
## Summary
- expand catalog with revoked and expired messages
- add timers and additional status handling in `useConsentNotifications`
- ensure toast and banner transitions reset previous message

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*
- `cd app-backend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685263bba8848327a0c1a71c35585bbc