### PR TITLE
Improve signup process and UI components

### DIFF
--- a/app-frontend/components/forms/DatePickerInput.tsx
+++ b/app-frontend/components/forms/DatePickerInput.tsx
@@ -1,7 +1,7 @@
 // ✅ Fichier 1 : DatePickerInput.tsx
 import React, { useState } from 'react';
-import { View, TouchableOpacity, Text, Platform, StyleSheet } from 'react-native';
-import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import DatePicker from 'react-native-date-picker';
 import { COLORS, SIZES } from '../../constants';
 
 interface DatePickerInputProps {
@@ -11,29 +11,25 @@ interface DatePickerInputProps {
 }
 
 export default function DatePickerInput({ value, onChange, placeholder = 'Date de naissance' }: DatePickerInputProps) {
-  const [show, setShow] = useState(false);
-
-  const onChangeInternal = (event: DateTimePickerEvent, selectedDate?: Date) => {
-    setShow(Platform.OS === 'ios');
-    if (selectedDate) {
-      onChange(selectedDate);
-    }
-  };
+  const [open, setOpen] = useState(false);
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity style={styles.input} onPress={() => setShow(true)}>
+      <TouchableOpacity style={styles.input} onPress={() => setOpen(true)}>
         <Text style={styles.text}>{value ? value.toLocaleDateString() : placeholder}</Text>
       </TouchableOpacity>
-      {show && (
-        <DateTimePicker
-          value={value || new Date()}
-          mode="date"
-          display="default"
-          onChange={onChangeInternal}
-          maximumDate={new Date()}
-        />
-      )}
+      <DatePicker
+        modal
+        open={open}
+        date={value || new Date()}
+        mode="date"
+        maximumDate={new Date()}
+        onConfirm={(date) => {
+          setOpen(false);
+          onChange(date);
+        }}
+        onCancel={() => setOpen(false)}
+      />
     </View>
   );
 }

--- a/app-frontend/components/forms/ImagePickerInput.tsx
+++ b/app-frontend/components/forms/ImagePickerInput.tsx
@@ -25,7 +25,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) return;
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ImagePicker.MediaType.Images,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
@@ -41,6 +41,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     const permission = await ImagePicker.requestCameraPermissionsAsync();
     if (!permission.granted) return;
     const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaType.Images,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,

--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, ToastAndroid } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ToastAndroid, ActivityIndicator } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
@@ -45,9 +45,7 @@ export default function SignupScreen() {
         formData.append('photo', { uri: photo, name, type: 'image/jpeg' } as any);
       }
 
-      const response = await axios.post(`${API_URL}/auth/signup`, formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      const response = await axios.post(`${API_URL}/auth/register`, formData);
       const { token, user } = response.data;
 
       if (!token || !user) {
@@ -113,7 +111,11 @@ export default function SignupScreen() {
       <DatePickerInput value={dateOfBirth} onChange={setDateOfBirth} />
       <PasswordInput value={password} onChangeText={setPassword} />
       <TouchableOpacity style={styles.button} onPress={handleSignup} disabled={loading}>
-        <Text style={styles.buttonText}>{loading ? 'Inscription...' : 'S’inscrire'}</Text>
+        {loading ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.buttonText}>S’inscrire</Text>
+        )}
       </TouchableOpacity>
       <TouchableOpacity onPress={handleLoginNavigation}>
         <Text style={styles.loginText}>Déjà un compte ? Se connecter</Text>


### PR DESCRIPTION
## Summary
- modernize image picker to use `ImagePicker.MediaType.Images`
- replace date picker with `react-native-date-picker`
- update signup screen to call `/auth/register` and show a spinner

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ab9b1b708327b98d8d8323a6b950