### PR TITLE
Improve signup with password strength check

### DIFF
--- a/app-frontend/components/forms/ImagePickerInput.tsx
+++ b/app-frontend/components/forms/ImagePickerInput.tsx
@@ -25,7 +25,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) return;
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaType.Images,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
@@ -41,7 +41,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     const permission = await ImagePicker.requestCameraPermissionsAsync();
     if (!permission.granted) return;
     const result = await ImagePicker.launchCameraAsync({
-      mediaTypes: ImagePicker.MediaType.Images,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,

--- a/app-frontend/components/forms/PasswordInput.tsx
+++ b/app-frontend/components/forms/PasswordInput.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { View, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, TextInput, TouchableOpacity, StyleSheet, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS, SIZES } from '../../constants';
+import zxcvbn from 'zxcvbn';
 
 interface PasswordInputProps {
   value: string;
@@ -11,6 +12,11 @@ interface PasswordInputProps {
 
 export default function PasswordInput({ value, onChangeText, placeholder = 'Mot de passe' }: PasswordInputProps) {
   const [secure, setSecure] = useState(true);
+  const strength = zxcvbn(value || '');
+  const score = strength.score;
+  const strengthLabel = ['Très faible', 'Faible', 'Moyen', 'Bon', 'Excellent'][score];
+  const strengthColor = ['#ff3b30', '#ff9500', '#ffcc00', '#34c759', COLORS.primary][score];
+
   return (
     <View style={styles.container}>
       <TextInput
@@ -23,6 +29,12 @@ export default function PasswordInput({ value, onChangeText, placeholder = 'Mot 
       <TouchableOpacity onPress={() => setSecure((s) => !s)} style={styles.iconContainer}>
         <Ionicons name={secure ? 'eye-off' : 'eye'} size={22} color={COLORS.text} />
       </TouchableOpacity>
+      {value.length > 0 && (
+        <View style={styles.strengthWrapper}>
+          <View style={[styles.strengthBar, { backgroundColor: strengthColor, width: `${(score + 1) * 20}%` }]} />
+          <Text style={[styles.strengthText, { color: strengthColor }]}>{strengthLabel}</Text>
+        </View>
+      )}
     </View>
   );
 }
@@ -44,5 +56,18 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 10,
     top: 12,
+  },
+  strengthWrapper: {
+    marginTop: 6,
+  },
+  strengthBar: {
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: COLORS.primary,
+  },
+  strengthText: {
+    marginTop: 2,
+    fontSize: 12,
+    fontFamily: 'Poppins-Regular',
   },
 });

--- a/app-frontend/package-lock.json
+++ b/app-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native-stack": "^7.3.13",
         "@stripe/stripe-react-native": "^0.45.0",
         "axios": "^1.9.0",
+        "date-fns": "^4.1.0",
         "expo": "~53.0.8",
         "expo-av": "^15.1.6",
         "expo-blur": "~14.1.4",
@@ -46,7 +47,8 @@
         "react-native-screens": "~4.10.0",
         "react-native-toast-message": "^2.3.0",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -5369,6 +5371,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -13419,6 +13431,12 @@
       "peerDependencies": {
         "zod": "^3.24.1"
       }
+    },
+    "node_modules/zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
+      "license": "MIT"
     }
   }
 }

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/native-stack": "^7.3.13",
     "@stripe/stripe-react-native": "^0.45.0",
     "axios": "^1.9.0",
+    "date-fns": "^4.1.0",
     "expo": "~53.0.8",
     "expo-av": "^15.1.6",
     "expo-blur": "~14.1.4",
@@ -49,7 +50,8 @@
     "react-native-screens": "~4.10.0",
     "react-native-toast-message": "^2.3.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -10,6 +10,7 @@ import ImagePickerInput from '../components/forms/ImagePickerInput';
 import DatePickerInput from '../components/forms/DatePickerInput';
 import PasswordInput from '../components/forms/PasswordInput';
 import { registerSchema } from '../lib/validation/registerSchema';
+import { differenceInYears } from 'date-fns';
 
 export default function SignupScreen() {
   const [email, setEmail] = useState('');
@@ -33,6 +34,10 @@ export default function SignupScreen() {
         dateOfBirth: dateOfBirth ?? undefined,
         photo: photo ?? undefined,
       });
+
+      if (parsed.dateOfBirth && differenceInYears(new Date(), parsed.dateOfBirth) < 18) {
+        throw new Error('Vous devez avoir au moins 18 ans');
+      }
 
       const formData = new FormData();
       formData.append('email', parsed.email);
@@ -71,7 +76,11 @@ export default function SignupScreen() {
       }
     } catch (error) {
       console.error('Erreur lors de l’inscription :', error?.response?.data || error.message);
-      ToastAndroid.show('Erreur lors de l’inscription', ToastAndroid.SHORT);
+      const message =
+        error?.response?.status === 409
+          ? 'Email déjà utilisé'
+          : error.message || 'Erreur lors de l’inscription';
+      ToastAndroid.show(message, ToastAndroid.SHORT);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- add password strength indicator using zxcvbn
- enforce age requirement during signup
- show specific error when email is already used
- include zxcvbn and date-fns dependencies
- fix image picker constant causing runtime error

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6ddae3483278197fce2da92b8bd