### PR TITLE
Fix signup multipart header

### DIFF
--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -64,9 +64,7 @@ export default function SignupScreen() {
         } as any);
       }
 
-      const response = await axios.post(`${API_URL}/auth/signup`, formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      const response = await axios.post(`${API_URL}/auth/signup`, formData);
 
       const { token, user } = response.data;
 


### PR DESCRIPTION
## Summary
- remove explicit multipart content-type header on signup

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd app-backend && npm test` *(fails: Missing script)*
- `cd ../app-frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852cfbe809483278201156cafdea7ae