### PR TITLE
Fix signup validation responses

### DIFF
--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -185,6 +185,12 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
     res.status(201).json({ token, user: { ...user, firstName: user.firstName ?? '', lastName: user.lastName ?? '' } });
   } catch (error) {
     console.error('Erreur signup:', error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ message: 'Erreur de validation', errors: error.errors });
+    }
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return res.status(409).json({ message: 'Email already in use' });
+    }
     res.status(500).json({ message: 'Erreur serveur', error: error.message });
   }
 });
@@ -217,6 +223,9 @@ app.post('/api/auth/register', upload.single('photo'), async (req, res) => {
     res.status(201).json({ token, user: { ...user, firstName: user.firstName ?? '', lastName: user.lastName ?? '' } });
   } catch (error) {
     console.error('Erreur register:', error);
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ message: 'Erreur de validation', errors: error.errors });
+    }
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
       return res.status(409).json({ message: 'Email already in use' });
     }

--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -64,9 +64,7 @@ export default function SignupScreen() {
         } as any);
       }
 
-      const response = await axios.post(`${API_URL}/auth/signup`, formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      const response = await axios.post(`${API_URL}/auth/signup`, formData);
 
       const { token, user } = response.data;
 


### PR DESCRIPTION
## Summary
- improve /auth/signup error handling with specific status codes
- align /auth/register error responses with signup

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd app-backend && npm test` *(fails: Missing script)*
- `cd ../app-frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852cfbe809483278201156cafdea7ae