### PR TITLE
Fix signup network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ MONGO_URI=<votre-URI-MongoDB>
 JWT_SECRET=<votre-clé-secrète>
 STRIPE_SECRET_KEY=<clé-secrète-stripe>
 
-Frontend (.env dans app-frontend ou directement dans app/config.js selon ton approche)
+Frontend (.env dans app-frontend)
 
-API_URL=http://localhost:5000
-STRIPE_PUBLISHABLE_KEY=<clé-publiable-stripe>
+# Utilisé côté mobile
+EXPO_PUBLIC_API_BASE_URL=http://localhost:5000
+EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=<clé-publiable-stripe>
 
 Tests
 

--- a/app-frontend/constants.js
+++ b/app-frontend/constants.js
@@ -1,12 +1,17 @@
 // ConsentAPP/app-frontend/constants.js
 
 // URL de base de votre backend (sans suffixe)
-export const API_BASE_URL = 'https://app-backend-h0p5.onrender.com';
+// Permet de surcharger l'URL du backend via une variable d'environnement
+// EXPO_PUBLIC_API_BASE_URL pour Expo (voir README).
+export const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL || 'https://app-backend-h0p5.onrender.com';
 
 // URL de l’API (préfixe /api)
 export const API_URL = `${API_BASE_URL}/api`;
 
+// Clé Stripe publiable (peut être surchargée par EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY)
 export const STRIPE_PUBLISHABLE_KEY =
+  process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
   'pk_test_51P5rcLA5nUL3grmuCdq4ktxeMp9RE7nKYRvcl4f7sYRfvyXBbS1bUg515Cni9MoeIlEg9Vo9YXxaAx5rhr2huM2b00Q5x9Dmli';
 
 export const COLORS = {

--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -9,10 +9,10 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import * as Haptics from 'expo-haptics';
-import axios from 'axios';
+import { api } from '../utils/api';
 import * as SecureStore from 'expo-secure-store';
 import { useAuth } from '../context/AuthContext';
-import { API_URL, COLORS, SIZES } from '../constants';
+import { COLORS, SIZES } from '../constants';
 import { useRouter } from 'expo-router';
 import PhotoUploader from '../components/forms/PhotoUploader';
 import DateInput from '../components/forms/DateInput';
@@ -64,7 +64,9 @@ export default function SignupScreen() {
         } as any);
       }
 
-      const response = await axios.post(`${API_URL}/auth/signup`, formData);
+      const response = await api.post('/auth/signup', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
 
       const { token, user } = response.data;
 


### PR DESCRIPTION
## Summary
- make API URL configurable at build time
- update signup to use shared axios instance with multipart handling
- document new env vars for the frontend

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530e7a381c83279b8924c097f8613e