### PR TITLE
Handle form signup without photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,19 @@ MONGO_URI=<votre-URI-MongoDB>
 JWT_SECRET=<votre-clé-secrète>
 STRIPE_SECRET_KEY=<clé-secrète-stripe>
 
-Frontend (.env dans app-frontend ou directement dans app/config.js selon ton approche)
+Frontend (.env dans app-frontend)
+(un fichier `.env.example` est fourni en référence)
 
-API_URL=http://localhost:5000
-STRIPE_PUBLISHABLE_KEY=<clé-publiable-stripe>
+# Utilisé côté mobile
+# Indiquez l'adresse du backend joignable depuis
+# l'émulateur ou le téléphone. Remplacez <IP> par
+# l'adresse locale de votre ordinateur (localhost ne
+# fonctionne pas sur appareil réel).
+EXPO_PUBLIC_API_BASE_URL=http://<IP>:5000
+EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=<clé-publiable-stripe>
+
+L'endpoint `/api/auth/signup` accepte aussi bien un corps JSON classique
+qu'un `multipart/form-data` lorsqu'une photo est envoyée.
 
 Tests
 
@@ -118,6 +127,10 @@ Certaines requêtes réseau (Lottie/icons) peuvent être bloquées si l’enviro
 assets10.lottiefiles.com
 
 img.icons8.com
+
+En cas d’erreur « Network Error » lors de l’inscription, assurez‑vous que
+`EXPO_PUBLIC_API_BASE_URL` pointe vers une adresse accessible par votre
+émulateur ou votre téléphone.
 
 Auteurs
 

--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -78,8 +78,9 @@ app.post('/api/stripe/webhook', express.raw({ type: 'application/json' }), async
   }
 });
 
-// Middleware JSON pour les autres routes (après le webhook)
+// Middleware JSON et urlencoded pour les autres routes (après le webhook)
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 const uploadDir = path.join(__dirname, 'uploads');
 app.use('/uploads', express.static(uploadDir));
 const storage = multer.diskStorage({
@@ -156,17 +157,22 @@ const encrypt = (data) => CryptoJS.AES.encrypt(data, process.env.AES_SECRET_KEY)
 const decrypt = (ciphertext) => CryptoJS.AES.decrypt(ciphertext, process.env.AES_SECRET_KEY).toString(CryptoJS.enc.Utf8);
 
 // Routes d'authentification
-// Route d'inscription acceptant l'upload optionnel d'une photo de profil
+// Route d'inscription acceptant l'upload optionnel d'une photo de profil.
+// Accepte également des données JSON classiques pour une meilleure
+// compatibilité avec d'anciennes versions du frontend.
 app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
   try {
-    const data = {
-      email: req.body.email,
-      password: req.body.password,
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      dateOfBirth: req.body.dateOfBirth,
-      photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
-    };
+    const isMultipart = req.is('multipart/form-data');
+    const data = isMultipart
+      ? {
+          email: req.body.email,
+          password: req.body.password,
+          firstName: req.body.firstName,
+          lastName: req.body.lastName,
+          dateOfBirth: req.body.dateOfBirth,
+          photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
+        }
+      : req.body;
     const parsed = signupSchema.parse(data);
     const hashedPassword = await bcrypt.hash(parsed.password, 10);
     const user = await prisma.user.create({
@@ -198,14 +204,17 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
 // Nouvelle route d'inscription avec upload de photo
 app.post('/api/auth/register', upload.single('photo'), async (req, res) => {
   try {
-    const data = {
-      email: req.body.email,
-      password: req.body.password,
-      firstName: req.body.firstName,
-      lastName: req.body.lastName,
-      dateOfBirth: req.body.dateOfBirth,
-      photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
-    };
+    const isMultipart = req.is('multipart/form-data');
+    const data = isMultipart
+      ? {
+          email: req.body.email,
+          password: req.body.password,
+          firstName: req.body.firstName,
+          lastName: req.body.lastName,
+          dateOfBirth: req.body.dateOfBirth,
+          photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
+        }
+      : req.body;
     const parsed = signupSchema.parse(data);
     const hashedPassword = await bcrypt.hash(parsed.password, 10);
     const user = await prisma.user.create({

--- a/app-frontend/.env.example
+++ b/app-frontend/.env.example
@@ -1,0 +1,6 @@
+# Example environment for the mobile app
+# Replace <IP> with the computer address reachable from your device
+EXPO_PUBLIC_API_BASE_URL=http://<IP>:5000
+
+# Optional: override the Stripe key used for payments
+# EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_12345

--- a/app-frontend/constants.js
+++ b/app-frontend/constants.js
@@ -1,12 +1,17 @@
 // ConsentAPP/app-frontend/constants.js
 
 // URL de base de votre backend (sans suffixe)
-export const API_BASE_URL = 'https://app-backend-h0p5.onrender.com';
+// Permet de surcharger l'URL du backend via une variable d'environnement
+// EXPO_PUBLIC_API_BASE_URL pour Expo (voir README).
+export const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL || 'https://app-backend-h0p5.onrender.com';
 
 // URL de l’API (préfixe /api)
 export const API_URL = `${API_BASE_URL}/api`;
 
+// Clé Stripe publiable (peut être surchargée par EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY)
 export const STRIPE_PUBLISHABLE_KEY =
+  process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
   'pk_test_51P5rcLA5nUL3grmuCdq4ktxeMp9RE7nKYRvcl4f7sYRfvyXBbS1bUg515Cni9MoeIlEg9Vo9YXxaAx5rhr2huM2b00Q5x9Dmli';
 
 export const COLORS = {

--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -9,10 +9,10 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import * as Haptics from 'expo-haptics';
-import axios from 'axios';
+import { api } from '../utils/api';
 import * as SecureStore from 'expo-secure-store';
 import { useAuth } from '../context/AuthContext';
-import { API_URL, COLORS, SIZES } from '../constants';
+import { COLORS, SIZES } from '../constants';
 import { useRouter } from 'expo-router';
 import PhotoUploader from '../components/forms/PhotoUploader';
 import DateInput from '../components/forms/DateInput';
@@ -47,24 +47,36 @@ export default function SignupScreen() {
         throw new Error('Vous devez avoir au moins 18 ans');
       }
 
-      const formData = new FormData();
-      formData.append('email', parsed.email);
-      formData.append('password', parsed.password);
-      formData.append('firstName', parsed.firstName);
-      if (parsed.lastName) formData.append('lastName', parsed.lastName);
-      if (parsed.dateOfBirth) {
-        formData.append('dateOfBirth', parsed.dateOfBirth.toISOString());
-      }
+      let payload: any;
       if (photo) {
+        const formData = new FormData();
+        formData.append('email', parsed.email);
+        formData.append('password', parsed.password);
+        formData.append('firstName', parsed.firstName);
+        if (parsed.lastName) formData.append('lastName', parsed.lastName);
+        if (parsed.dateOfBirth) {
+          formData.append('dateOfBirth', parsed.dateOfBirth.toISOString());
+        }
         const name = photo.split('/').pop()?.split('?')[0] || 'photo.jpg';
         formData.append('photo', {
           uri: photo,
           name,
           type: 'image/jpeg',
         } as any);
+        payload = formData;
+      } else {
+        payload = {
+          email: parsed.email,
+          password: parsed.password,
+          firstName: parsed.firstName,
+          lastName: parsed.lastName,
+          dateOfBirth: parsed.dateOfBirth
+            ? parsed.dateOfBirth.toISOString()
+            : undefined,
+        };
       }
 
-      const response = await axios.post(`${API_URL}/auth/signup`, formData);
+      const response = await api.post('/auth/signup', payload);
 
       const { token, user } = response.data;
 
@@ -92,9 +104,11 @@ export default function SignupScreen() {
     } catch (error: any) {
       console.error('Erreur lors de l’inscription :', error?.response?.data || error.message);
       const message =
-        error?.response?.status === 409
-          ? 'Email déjà utilisé'
-          : error.message || 'Erreur lors de l’inscription';
+        error.message === 'Network Error'
+          ? "Impossible de contacter le serveur. Vérifiez l'URL EXPO_PUBLIC_API_BASE_URL"
+          : error?.response?.status === 409
+            ? 'Email déjà utilisé'
+            : error.message || 'Erreur lors de l’inscription';
       ToastAndroid.show(message, ToastAndroid.SHORT);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     } finally {

--- a/app-frontend/utils/api.js
+++ b/app-frontend/utils/api.js
@@ -6,14 +6,12 @@ import { API_URL, API_BASE_URL } from '../constants';
 const api = axios.create({
   baseURL: API_URL,
   timeout: 10000,
-  headers: { 'Content-Type': 'application/json' },
 });
 
 // Instance pour les routes racines (e.g. /test-db)
 const rootApi = axios.create({
   baseURL: API_BASE_URL,
   timeout: 10000,
-  headers: { 'Content-Type': 'application/json' },
 });
 
 // Intercepteur : injecte le token dans chaque requête API (instance api)


### PR DESCRIPTION
## Summary
- send plain JSON when no image is selected in signup
- allow Express to parse URL encoded bodies
- document env setup for API base URL and network error
- warn user when signup fails due to network error

## Testing
- `npm run lint` *(fails: package.json missing)*
- `cd app-frontend && npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530e7a381c83279b8924c097f8613e