### PR TITLE
Fix signup photo upload

### DIFF
--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -79,9 +79,9 @@ export default function SignupScreen() {
       }
 
       const response = await api.post('/auth/signup', payload, {
-        headers: isFormData
-          ? { 'Content-Type': 'multipart/form-data' }
-          : { 'Content-Type': 'application/json' },
+        // Laisser Axios gérer automatiquement l'en-tête multipart pour FormData
+        // (inclus le boundary). Si aucune photo n'est envoyée, on précise JSON.
+        headers: isFormData ? {} : { 'Content-Type': 'application/json' },
       });
 
       const { token, user } = response.data;


### PR DESCRIPTION
## Summary
- ensure axios handles multipart headers automatically during signup

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm test` in `app-backend` *(fails: Missing script)*
- `npm test` in `app-frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853290f25308327a87854b051aec394