### PR TITLE
Fix signup photo upload

### DIFF
--- a/app-frontend/screens/SignupScreen.tsx
+++ b/app-frontend/screens/SignupScreen.tsx
@@ -78,11 +78,15 @@ export default function SignupScreen() {
         };
       }
 
-      const response = await api.post('/auth/signup', payload, {
-        headers: isFormData
-          ? { 'Content-Type': 'multipart/form-data' }
-          : { 'Content-Type': 'application/json' },
-      });
+      // Lorsqu'un FormData est envoyé, Axios définit automatiquement
+      // l'en-tête multipart avec la bonne boundary. Il ne faut donc pas le
+      // surcharger, sinon le backend reçoit des champs vides. On ne fixe
+      // explicitement l'en-tête que pour les requêtes JSON classiques.
+      const config = isFormData
+        ? undefined
+        : { headers: { 'Content-Type': 'application/json' } };
+
+      const response = await api.post('/auth/signup', payload, config);
 
       const { token, user } = response.data;
 


### PR DESCRIPTION
## Summary
- let Axios set the multipart headers automatically during signup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `app-backend` *(fails: Missing script)*
- `npm test` in `app-frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853290f25308327a87854b051aec394