### PR TITLE
Fix signup form logs and CORS

### DIFF
--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -23,12 +23,12 @@ const prisma = new PrismaClient({
   log: ['error'],
 });
 
-// Configuration CORS pour Railway
-app.use(cors({
-  origin: '*', // Autorise toutes les origines pour les tests
-  // origin: ['https://*.expo.dev', 'exp://192.168.95.14:8081', 'http://localhost:8081'],
-  credentials: true,
-}));
+// Configuration CORS
+// En phase de développement on autorise toutes les origines. Il est préférable
+// d'ajuster cette liste via la variable d'environnement CORS_ORIGIN en
+// production.
+const corsOrigin = process.env.CORS_ORIGIN || '*';
+app.use(cors({ origin: corsOrigin }));
 
 // Middleware pour le webhook Stripe (doit être avant express.json())
 app.post('/api/stripe/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
@@ -173,6 +173,12 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
   try {
     const isMultipart = req.is('multipart/form-data');
 
+    console.log('Signup request received. Multipart:', isMultipart);
+    if (isMultipart) {
+      console.log('Fields:', req.body);
+      console.log('File:', req.file);
+    }
+
     let body = {};
     if (isMultipart) {
       // Lorsque le frontend envoie un FormData, Express ne parse pas
@@ -230,6 +236,7 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
       },
     });
   } catch (error) {
+    console.error('Erreur lors de l\'inscription :', error);
     if (error instanceof z.ZodError) {
       return res.status(400).json({ message: 'Erreur de validation', errors: error.errors });
     }

--- a/app-frontend/utils/api.js
+++ b/app-frontend/utils/api.js
@@ -5,13 +5,14 @@ import { API_URL, API_BASE_URL } from '../constants';
 // Instance principale pour les routes sous /api
 const api = axios.create({
   baseURL: API_URL,
-  timeout: 10000,
+  // Un délai plus élevé évite les faux timeouts lors de l'envoi de fichiers
+  timeout: 30000,
 });
 
 // Instance pour les routes racines (e.g. /test-db)
 const rootApi = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 30000,
 });
 
 // Intercepteur : injecte le token dans chaque requête API (instance api)


### PR DESCRIPTION
## Summary
- relax CORS configuration and allow customizing origin via env var
- add debug logs for multipart signup requests
- log errors when signup fails
- increase axios timeouts to avoid network errors with image uploads

## Testing
- `npm test` (fails: package.json missing)
- `cd app-backend && npm test` (fails: no test script)
- `cd app-frontend && npm test` (fails: no test script)


------
https://chatgpt.com/codex/tasks/task_e_685418083cac832788ae03bfeb43b9c4