### PR TITLE
Integrate Cloudinary upload

### DIFF
--- a/app-backend/package-lock.json
+++ b/app-backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^2.4.3",
+        "cloudinary": "^2.7.0",
         "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
         "dotenv": "^16.0.3",
@@ -20,6 +21,7 @@
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.0",
         "multer": "^2.0.1",
+        "streamifier": "^0.1.1",
         "stripe": "^11.14.0",
         "zod": "^3.24.2"
       },
@@ -816,6 +818,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
       }
     },
     "node_modules/concat-map": {
@@ -1653,6 +1668,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2027,6 +2048,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -2293,6 +2325,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamifier": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+      "integrity": "sha512-zDgl+muIlWzXNsXeyUfOk9dChMjlpkq0DRsxujtYPgyJ676yQ8jEm6zzaaWHFDg5BNcLuif0eD2MTyJdZqXpdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/streamsearch": {

--- a/app-backend/package.json
+++ b/app-backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^2.4.3",
+    "cloudinary": "^2.7.0",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
     "dotenv": "^16.0.3",
@@ -19,6 +20,7 @@
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.0",
     "multer": "^2.0.1",
+    "streamifier": "^0.1.1",
     "stripe": "^11.14.0",
     "zod": "^3.24.2"
   },

--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -10,8 +10,14 @@ const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const CryptoJS = require('crypto-js');
 const { OAuth2Client } = require('google-auth-library');
 const multer = require('multer');
-const path = require('path');
-const fs = require('fs');
+const cloudinary = require('cloudinary').v2;
+const streamifier = require('streamifier');
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
 
 // Initialisation de l'application et Prisma
 const app = express();
@@ -81,19 +87,7 @@ app.post('/api/stripe/webhook', express.raw({ type: 'application/json' }), async
 // Middleware JSON et urlencoded pour les autres routes (après le webhook)
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-const uploadDir = path.join(__dirname, 'uploads');
-app.use('/uploads', express.static(uploadDir));
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    fs.mkdirSync(uploadDir, { recursive: true });
-    cb(null, uploadDir);
-  },
-  filename: (req, file, cb) => {
-    const ext = path.extname(file.originalname);
-    cb(null, `${Date.now()}-${Math.round(Math.random() * 1e9)}${ext}`);
-  }
-});
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
 // Middleware de validation Zod
 const validate = (schema) => async (req, res, next) => {
@@ -184,13 +178,27 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
       // Lorsque le frontend envoie un FormData, Express ne parse pas
       // automatiquement les valeurs JSON. On récupère donc les champs
       // manuellement depuis req.body et on ajoute l'URL de la photo si présente.
+      let uploadedUrl;
+      if (req.file) {
+        uploadedUrl = await new Promise((resolve, reject) => {
+          const stream = cloudinary.uploader.upload_stream(
+            { folder: 'consent-app' },
+            (err, result) => {
+              if (err) return reject(err);
+              resolve(result.secure_url);
+            }
+          );
+          streamifier.createReadStream(req.file.buffer).pipe(stream);
+        });
+      }
+
       body = {
         email: req.body.email,
         password: req.body.password,
         firstName: req.body.firstName,
         lastName: req.body.lastName,
         dateOfBirth: req.body.dateOfBirth,
-        photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
+        photoUrl: uploadedUrl,
       };
     } else {
       body = req.body;
@@ -254,16 +262,32 @@ app.post('/api/auth/signup', upload.single('photo'), async (req, res) => {
 app.post('/api/auth/register', upload.single('photo'), async (req, res) => {
   try {
     const isMultipart = req.is('multipart/form-data');
-    const data = isMultipart
-      ? {
-          email: req.body.email,
-          password: req.body.password,
-          firstName: req.body.firstName,
-          lastName: req.body.lastName,
-          dateOfBirth: req.body.dateOfBirth,
-          photoUrl: req.file ? `/uploads/${req.file.filename}` : undefined,
-        }
-      : req.body;
+    let data;
+    if (isMultipart) {
+      let uploadedUrl;
+      if (req.file) {
+        uploadedUrl = await new Promise((resolve, reject) => {
+          const stream = cloudinary.uploader.upload_stream(
+            { folder: 'consent-app' },
+            (err, result) => {
+              if (err) return reject(err);
+              resolve(result.secure_url);
+            }
+          );
+          streamifier.createReadStream(req.file.buffer).pipe(stream);
+        });
+      }
+      data = {
+        email: req.body.email,
+        password: req.body.password,
+        firstName: req.body.firstName,
+        lastName: req.body.lastName,
+        dateOfBirth: req.body.dateOfBirth,
+        photoUrl: uploadedUrl,
+      };
+    } else {
+      data = req.body;
+    }
     const parsed = signupSchema.parse(data);
     const hashedPassword = await bcrypt.hash(parsed.password, 10);
     const user = await prisma.user.create({


### PR DESCRIPTION
## Summary
- add cloudinary and streamifier dependencies
- configure cloudinary in the Express backend
- upload profile pictures directly to Cloudinary
- store uploaded image URL in users table
- update signup and register routes

## Testing
- `npm install cloudinary streamifier --save`


------
https://chatgpt.com/codex/tasks/task_e_6854602392988327a67672ca9c8e0b18