### PR TITLE
Fix signup URL handling and update image picker API

### DIFF
--- a/app-frontend/components/forms/ImagePickerInput.tsx
+++ b/app-frontend/components/forms/ImagePickerInput.tsx
@@ -25,7 +25,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     if (!permission.granted) return;
     const result = await ImagePicker.launchImageLibraryAsync({
       // Utilise la valeur compatible avec toutes les versions d'Expo
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: [ImagePicker.MediaType.Image],
 
       allowsEditing: true,
       aspect: [1, 1],
@@ -42,7 +42,7 @@ export default function ImagePickerInput({ value, onChange }: ImagePickerInputPr
     const permission = await ImagePicker.requestCameraPermissionsAsync();
     if (!permission.granted) return;
     const result = await ImagePicker.launchCameraAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: [ImagePicker.MediaType.Image],
 
       allowsEditing: true,
       aspect: [1, 1],

--- a/app-frontend/components/forms/PhotoUploader.tsx
+++ b/app-frontend/components/forms/PhotoUploader.tsx
@@ -33,7 +33,7 @@ export default function PhotoUploader({ value, onChange }: PhotoUploaderProps) {
     if (!permission.granted) return;
 
     const pickerOptions: ImagePicker.ImagePickerOptions = {
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: [ImagePicker.MediaType.Image],
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,

--- a/app-frontend/constants.js
+++ b/app-frontend/constants.js
@@ -18,7 +18,16 @@ if (!process.env.EXPO_PUBLIC_API_BASE_URL) {
   }
 }
 
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || fallbackBase;
+// Base définie par l'environnement ou fallback
+const rawBase = process.env.EXPO_PUBLIC_API_BASE_URL || fallbackBase;
+
+// Nettoie l'URL en supprimant un éventuel suffixe /api ou un slash final
+let sanitizedBase = rawBase.replace(/\/$/, '');
+if (sanitizedBase.endsWith('/api')) {
+  sanitizedBase = sanitizedBase.slice(0, -4);
+}
+
+export const API_BASE_URL = sanitizedBase;
 
 // URL de l’API (préfixe /api)
 export const API_URL = `${API_BASE_URL}/api`;


### PR DESCRIPTION
## Summary
- sanitize the API base URL to avoid duplicate `/api`
- use `ImagePicker.MediaType.Image` to remove deprecation warnings

## Testing
- `npm test` *(fails: package.json missing)*
- `npm test` in app-backend *(fails: script missing)*
- `npm test` in app-frontend *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_685db979941c832784823e09630aac83